### PR TITLE
Add install button logic and console logs for beforeinstallprompt and butInstall-clicked events

### DIFF
--- a/client/src/js/install.js
+++ b/client/src/js/install.js
@@ -18,6 +18,8 @@ window.addEventListener('beforeinstallprompt', (event) => {
     event.preventDefault();
     // Stash the event so it can be triggered later. the event object here is a BeforeInstallPromptEvent object which contains a prompt() method and a userChoice property that returns a Promise that resolves to a DOMString indicating what choice the user made.
     deferredPrompt = event;
+    console.log('beforeinstallprompt fired');
+    console.log(event);
     // Update UI to notify the user they can add to home screen
     butInstall.style.display = 'block';
 });
@@ -29,8 +31,11 @@ butInstall.addEventListener('click', async () => {
 
     // Show the install prompt
     deferredPrompt.prompt();
+    console.log('butInstall-clicked');
+    console.log(deferredPrompt.prompt());
     // Wait for the user to respond to the prompt
     const { outcome } = await deferredPrompt.userChoice;
+    console.log(outcome);
     if (outcome === 'accepted') {
         console.log('User accepted the install prompt');
     } else {

--- a/client/src/js/install.js
+++ b/client/src/js/install.js
@@ -1,11 +1,52 @@
+// Desc: JavaScript file for the install button
+// =================================================
+
+// Get the install button
+// =================================================
 const butInstall = document.getElementById('buttonInstall');
+// =================================================
 
 // Logic for installing the PWA
-// TODO: Add an event handler to the `beforeinstallprompt` event
-window.addEventListener('beforeinstallprompt', (event) => {});
+// =================================================
 
-// TODO: Implement a click event handler on the `butInstall` element
-butInstall.addEventListener('click', async () => {});
+// an event handler to the `beforeinstallprompt` event
+// =================================================
+let deferredPrompt;
 
-// TODO: Add an handler for the `appinstalled` event
-window.addEventListener('appinstalled', (event) => {});
+window.addEventListener('beforeinstallprompt', (event) => {
+    // Prevent Chrome from automatically showing the prompt
+    event.preventDefault();
+    // Stash the event so it can be triggered later. the event object here is a BeforeInstallPromptEvent object which contains a prompt() method and a userChoice property that returns a Promise that resolves to a DOMString indicating what choice the user made.
+    deferredPrompt = event;
+    // Update UI to notify the user they can add to home screen
+    butInstall.style.display = 'block';
+});
+// =================================================
+
+// Implement a click event handler on the `butInstall` element
+// =================================================
+butInstall.addEventListener('click', async () => {
+
+    // Show the install prompt
+    deferredPrompt.prompt();
+    // Wait for the user to respond to the prompt
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === 'accepted') {
+        console.log('User accepted the install prompt');
+    } else {
+        console.log('User dismissed the install prompt');
+    }
+    // We've used the prompt, and can't use it again, throw it away
+    deferredPrompt = null;
+    // Hide the app provided install promotion
+    butInstall.style.display = 'none';
+
+});
+// =================================================
+
+// Add an handler for the `appinstalled` event
+// =================================================
+window.addEventListener('appinstalled', (event) => {
+    console.log('App was installed', event);
+});
+// =================================================


### PR DESCRIPTION
This pull request adds the logic for the install button functionality and includes console logs for the `beforeinstallprompt` and `butInstall-clicked` events. The `beforeinstallprompt` event is handled by preventing Chrome from automatically showing the prompt and stashing the event for later use. The `butInstall` element has a click event handler that shows the install prompt and waits for the user to respond. The `appinstalled` event is also handled to log when the app is installed. This PR improves the user experience by providing a way to install the PWA and adds logging for important events.

Fixes #1234